### PR TITLE
clean slate and legendary spirit fix

### DIFF
--- a/src/main/java/net/server/channel/handlers/ScrollHandler.java
+++ b/src/main/java/net/server/channel/handlers/ScrollHandler.java
@@ -79,7 +79,7 @@ public final class ScrollHandler extends AbstractPacketHandler {
                 if (ItemConstants.isCleanSlate(scroll.getItemId()) && !ii.canUseCleanSlate(toScroll)) {
                     announceCannotScroll(c, legendarySpirit);
                     return;
-                } else if (!ItemConstants.isModifierScroll(scroll.getItemId()) && toScroll.getUpgradeSlots() < 1) {
+                } else if (!ItemConstants.isModifierScroll(scroll.getItemId()) && !ItemConstants.isCleanSlate(scroll.getItemId()) && toScroll.getUpgradeSlots() < 1) {
                     announceCannotScroll(c, legendarySpirit);   // thanks onechord for noticing zero upgrade slots freezing Legendary Scroll UI
                     return;
                 }
@@ -180,7 +180,7 @@ public final class ScrollHandler extends AbstractPacketHandler {
 
     private static void announceCannotScroll(Client c, boolean legendarySpirit) {
         if (legendarySpirit) {
-            c.sendPacket(PacketCreator.getScrollEffect(c.getPlayer().getId(), Equip.ScrollResult.FAIL, false, false));
+            c.sendPacket(PacketCreator.legendarySpiritCannotScroll(c.getPlayer().getId()));
         } else {
             c.sendPacket(PacketCreator.getInventoryFull());
         }

--- a/src/main/java/tools/PacketCreator.java
+++ b/src/main/java/tools/PacketCreator.java
@@ -2522,6 +2522,16 @@ public class PacketCreator {
         return p;
     }
 
+    public static Packet legendarySpiritCannotScroll(int chr) { // suggested by teto
+        OutPacket p = OutPacket.create(SendOpcode.SHOW_SCROLL_EFFECT);
+        p.writeInt(chr);
+        p.writeByte(-1); // CUIEnchantDlg::SetResult => CUtilDlg::Notice("You cannot use a Scroll with this item.");
+        p.writeBool(false);
+        p.writeBool(true); // bEnchantSkill
+        p.writeBool(false);
+        return p;
+    }
+
     public static Packet removePlayerFromMap(int chrId) {
         OutPacket p = OutPacket.create(SendOpcode.REMOVE_PLAYER_FROM_MAP);
         p.writeInt(chrId);


### PR DESCRIPTION
Clean slate scrolls could not be used on equips with 0 slots remaining. Additionally, using a scroll with legendary spirit on an equip with 0 slots remaining would freeze the legendary spirit window. This fixes both issues by adding an isCleanSlate check and sending a different packet in the legendary spirit case (the player will still need to dispose after).

## Description
<!-- Describe your changes in detail -->

## Checklist before requesting a review
<!-- Mark with "x" inside the square brackets -->
- [ ] I have performed a self-review of my code
- [ ] I have tested my changes
- [ ] I have added unit tests that prove my changes work

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->
